### PR TITLE
Fix easing and optimise > 3 digit Bpm display

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -57,6 +57,7 @@ Application {
                                  app.height * 0.26
 
     onArcEndChanged: canvas.requestPaint()
+    onArcBpmOffsetChanged: canvas.requestPaint()
 
     HrmSensor {
         active: true
@@ -79,7 +80,7 @@ Application {
                          pulseToggle = true
     }
 
-    Behavior on arcBpmGap { NumberAnimation { duration: 100; easing.type: Easing.Linear} }
+    Behavior on arcBpmGap { NumberAnimation { duration: 100; easing.type: Easing.OutCirc} }
     Behavior on arcBpmOffset { NumberAnimation { duration: 1000; easing.type: Easing.OutCirc } }
     Behavior on arcEnd { NumberAnimation { duration: arcAnimationDuration; easing.type: app.lastBpm === 0 ? Easing.Linear : Easing.OutInSine } }
     Behavior on arcStart { NumberAnimation { duration: arcAnimationDuration; easing.type: app.lastBpm === 0 ? Easing.Linear : Easing.OutInSine } }

--- a/src/main.qml
+++ b/src/main.qml
@@ -128,6 +128,7 @@ Application {
                                 app.height*0.29 :
                                 app.height*0.33 :
                             app.height*0.06
+        font.styleName: app.bpm / 100 >= 1 ? "SemiCondensed" : ""
         text: app.bpm > 0 ?
                   app.bpm :
                   //% "Measuring…"

--- a/src/main.qml
+++ b/src/main.qml
@@ -124,11 +124,11 @@ Application {
                                 -app.width * 0.008 :
                                 0
         font.pixelSize: app.bpm > 0 ?
-                            app.bpm / 100 >= 1 ?
+                            app.bpm >= 100 ?
                                 app.height*0.29 :
                                 app.height*0.33 :
                             app.height*0.06
-        font.styleName: app.bpm / 100 >= 1 ? "SemiCondensed" : ""
+        font.styleName: app.bpm >= 100 ? "SemiCondensed" : ""
         text: app.bpm > 0 ?
                   app.bpm :
                   //% "Measuring…"


### PR DESCRIPTION
- The ArcBpmOffset lagged behind the lastBpm text
- The Bpm runwidth was to wide when hitting 3 digit numbers

New lagless behaviour: after https://github.com/eLtMosen/asteroid-hrm/commit/8db5e27bc7bcb4954174419a0ec433e30a49d571

https://user-images.githubusercontent.com/15074193/156948162-520563c6-907e-4855-8774-4b20387ecb50.mp4