### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ ecm_find_qmlmodule(org.asteroid.controls 1.0)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-hrm.in
+	${CMAKE_BINARY_DIR}/asteroid-hrm
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-hrm
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-hrm)
 

--- a/asteroid-hrm.desktop.template
+++ b/asteroid-hrm.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-hrm
+Exec=asteroid-hrm
 Icon=ios-pulse-outline
 X-Asteroid-Center-Color=#0097A6
 X-Asteroid-Outer-Color=#00060C

--- a/asteroid-hrm.in
+++ b/asteroid-hrm.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-hrm.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-hrm main.cpp resources.qrc)
-set_target_properties(asteroid-hrm PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-hrm PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-hrm PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-hrm
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker