### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -89,7 +89,7 @@ Application {
         width: Dims.w(100)
         anchors {
             centerIn: parent
-            verticalCenterOffset: DeviceInfo.flatTireHeight/2
+            verticalCenterOffset: DeviceSpecs.flatTireHeight/2
         }
 
         Canvas {


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56