### PR TITLE
feat: port to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.6.0)
 
 project(asteroid-hrm
-	VERSION 0.0.1
+	VERSION 2.0
 	DESCRIPTION "Demo app for heart-rate-monitor bpm retrieval")
 
 find_package(ECM REQUIRED NO_MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.6.0)
 
-project(asteroid-hrm
+project(
+	asteroid-hrm
 	VERSION 2.0
-	DESCRIPTION "Demo app for heart-rate-monitor bpm retrieval")
+	DESCRIPTION "Demo app for heart-rate-monitor bpm retrieval"
+)
 
 find_package(ECM REQUIRED NO_MODULE)
 find_package(AsteroidApp REQUIRED)
@@ -20,12 +22,16 @@ ecm_find_qmlmodule(org.asteroid.controls 1.0)
 
 add_subdirectory(src)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-hrm.in
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/asteroid-hrm.in
 	${CMAKE_BINARY_DIR}/asteroid-hrm
-	@ONLY)
+	@ONLY
+)
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-hrm
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+	PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-hrm
+	DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-hrm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,18 +7,20 @@ project(
 )
 
 find_package(ECM REQUIRED NO_MODULE)
-find_package(AsteroidApp REQUIRED)
+find_package(AsteroidApp6 REQUIRED)
 
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ASTEROID_MODULE_PATH})
 
 include(FeatureSummary)
 include(GNUInstallDirs)
 include(ECMFindQmlModule)
-include(AsteroidCMakeSettings)
-include(AsteroidTranslations)
+include(Asteroid6CMakeSettings)
+include(Asteroid6Translations)
 
-ecm_find_qmlmodule(QtSensors 5.11)
+ecm_find_qmlmodule(QtSensors 6.10)
 ecm_find_qmlmodule(org.asteroid.controls 1.0)
+ecm_find_qmlmodule(org.asteroid.utils 1.0)
+ecm_find_qmlmodule(Nemo.KeepAlive 1.1)
 
 add_subdirectory(src)
 

--- a/asteroid-hrm.in
+++ b/asteroid-hrm.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-hrm.so
+exec invoker --single-instance --type=qt6 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-hrm.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,13 @@
 add_library(asteroid-hrm main.cpp resources.qrc)
 set_target_properties(asteroid-hrm PROPERTIES PREFIX "")
 
-target_link_libraries(asteroid-hrm PUBLIC
-	Asteroid::AsteroidApp)
+target_link_libraries(
+	asteroid-hrm
+	PUBLIC
+		Asteroid::AsteroidApp
+)
 
-install(TARGETS asteroid-hrm
-	DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(
+	TARGETS asteroid-hrm
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ set_target_properties(asteroid-hrm PROPERTIES PREFIX "")
 target_link_libraries(
 	asteroid-hrm
 	PUBLIC
-		Asteroid::AsteroidApp
+		Asteroid::AsteroidApp6
 )
 
 install(

--- a/src/main.qml
+++ b/src/main.qml
@@ -17,11 +17,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtSensors 5.11
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import Nemo.KeepAlive 1.1
+import QtQuick
+import QtSensors
+import org.asteroid.controls
+import org.asteroid.utils
+import Nemo.KeepAlive
 
 Application {
     id: app


### PR DESCRIPTION
This needs https://github.com/AsteroidOS/qtsensors to be updated to Qt6 as well. Ideally that gets upstreamed to Qt so there is no need to keep a fork around.