### PR TITLE
Build-time QML pre-compilation via asteroid_app_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
-add_library(asteroid-hrm main.cpp resources.qrc)
+add_library(asteroid-hrm main.cpp)
 set_target_properties(asteroid-hrm PROPERTIES PREFIX "")
+
+asteroid_app_qml_module(asteroid-hrm
+	main.qml
+)
 
 target_link_libraries(
 	asteroid-hrm

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource prefix="/">
-        <file>main.qml</file>
-    </qresource>
-</RCC>


### PR DESCRIPTION
The .so ships pre-compiled QML bytecode and the engine skips the parse/JIT pipeline on every launch.